### PR TITLE
Add method to read property

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ irb > ipa_file.bundle_identifier
  => "com.dcrails.multig"
 irb > ipa_file.icon_prerendered
  => false
+irb > ipa_file.get_property('CFBundleDisplayName')
+ => "MultiG"
 ```
 
 ## Supported ruby versions

--- a/lib/read_ipa/info_plist.rb
+++ b/lib/read_ipa/info_plist.rb
@@ -75,5 +75,9 @@ module ReadIpa
       end
       return false
     end
+
+    def get_property(property_name)
+      @plist.fetch(property_name, nil)
+    end
   end
 end

--- a/test/test_info_plist.rb
+++ b/test/test_info_plist.rb
@@ -63,4 +63,12 @@ class InfoPlistTest < Minitest::Test
   def test_not_for_ipad
     assert_equal(false, @iphone_only_info_plist.for_ipad?)
   end
+
+  def test_get_property
+    assert_equal(@info_plist.get_property('CFBundleExecutable'), "MultiG" )
+  end
+
+  def test_get_property_nil
+    assert_nil(@info_plist.get_property('CFBundleNameNil'))
+  end
 end


### PR DESCRIPTION
This change is to create a new function get_property which helps users to get specific properties of InfoPlist